### PR TITLE
Add Yaml formatter

### DIFF
--- a/cmd/debug.go
+++ b/cmd/debug.go
@@ -15,9 +15,17 @@
 package cmd
 
 import (
+	"strings"
+
 	"github.com/anduintransaction/rivendell/project"
+	"github.com/anduintransaction/rivendell/project/formatters"
 	"github.com/anduintransaction/rivendell/utils"
 	"github.com/spf13/cobra"
+)
+
+var (
+	outputFormat string
+	filterGroups []string
 )
 
 // debugCmd represents the debug command
@@ -31,10 +39,25 @@ var debugCmd = &cobra.Command{
 		if err != nil {
 			utils.Fatal(err)
 		}
-		p.Debug()
+
+		var formatter project.Formatter
+		switch strings.ToLower(outputFormat) {
+		case "console":
+			formatter = formatters.NewConsoleFormatter()
+		case "yaml":
+			formatter = formatters.NewYamlFormatter()
+		default:
+			utils.Warn("Unknown output formatter. Fallback to console")
+			formatter = formatters.NewConsoleFormatter()
+		}
+
+		p.Debug(formatter, filterGroups)
 	},
 }
 
 func init() {
 	RootCmd.AddCommand(debugCmd)
+
+	debugCmd.Flags().StringVarP(&outputFormat, "output", "o", "console", "print format. One of: console|yaml")
+	debugCmd.Flags().StringSliceVar(&filterGroups, "filter-groups", []string{}, "Only print resource groups")
 }

--- a/project/formatters/console.go
+++ b/project/formatters/console.go
@@ -1,0 +1,36 @@
+package formatters
+
+import (
+	"fmt"
+
+	"github.com/anduintransaction/rivendell/project"
+	"github.com/anduintransaction/rivendell/utils"
+)
+
+type ConsoleFormatter struct{}
+
+func NewConsoleFormatter() *ConsoleFormatter {
+	return &ConsoleFormatter{}
+}
+
+func (f *ConsoleFormatter) Format(p *project.Project, filterGroups []string) {
+	m := utils.StringSliceToMap(filterGroups)
+	p.PrintCommonInfo()
+	p.WalkForward(func(g *project.ResourceGroup) error {
+		if len(m) > 0 && !m[g.Name] {
+			return nil
+		}
+
+		utils.Info("Resource group %q", g.Name)
+		for _, rf := range g.ResourceFiles {
+			utils.Info2("Resource file %q", rf.FilePath)
+			fmt.Println()
+			for _, r := range rf.Resources {
+				fmt.Println(r.RawContent)
+				fmt.Println()
+			}
+		}
+		fmt.Println()
+		return nil
+	})
+}

--- a/project/formatters/yaml.go
+++ b/project/formatters/yaml.go
@@ -1,0 +1,37 @@
+package formatters
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/anduintransaction/rivendell/project"
+	"github.com/anduintransaction/rivendell/utils"
+)
+
+type YamlFormatter struct{}
+
+func NewYamlFormatter() *YamlFormatter {
+	return &YamlFormatter{}
+}
+
+func (f *YamlFormatter) Format(p *project.Project, filterGroups []string) {
+	m := utils.StringSliceToMap(filterGroups)
+	out := os.Stdout
+	sep := "---"
+
+	p.WalkForward(func(g *project.ResourceGroup) error {
+		if len(m) > 0 && !m[g.Name] {
+			return nil
+		}
+
+		for _, rf := range g.ResourceFiles {
+			for _, r := range rf.Resources {
+				fmt.Fprintf(out, "# Resource group %q - Resource file %q\n", g.Name, rf.FilePath)
+				fmt.Fprintln(out)
+				fmt.Fprintln(out, r.RawContent)
+				fmt.Fprintln(out, sep)
+			}
+		}
+		return nil
+	})
+}

--- a/project/project.go
+++ b/project/project.go
@@ -17,6 +17,10 @@ const (
 	waitCount = 10
 )
 
+type Formatter interface {
+	Format(p *Project, filterGroups []string)
+}
+
 // Project holds configuration for a rivendell task
 type Project struct {
 	rootDir               string
@@ -54,21 +58,8 @@ func ReadProject(projectFile, namespace, context, kubeConfig string, variables m
 }
 
 // Debug .
-func (p *Project) Debug() {
-	p.PrintCommonInfo()
-	p.resourceGraph.WalkForward(func(g *ResourceGroup) error {
-		utils.Info("Resource group %q", g.Name)
-		for _, rf := range g.ResourceFiles {
-			utils.Info2("Resource file %q", rf.FilePath)
-			fmt.Println()
-			for _, r := range rf.Resources {
-				fmt.Println(r.RawContent)
-				fmt.Println()
-			}
-		}
-		fmt.Println()
-		return nil
-	})
+func (p *Project) Debug(f Formatter, filterGroups []string) {
+	f.Format(p, filterGroups)
 }
 
 // Up .
@@ -215,6 +206,10 @@ func (p *Project) PrintRestartPlan(pods []string) {
 	for _, pod := range pods {
 		fmt.Printf(" - %s\n", pod)
 	}
+}
+
+func (p *Project) WalkForward(fn func(g *ResourceGroup) error) error {
+	return p.resourceGraph.WalkForward(fn)
 }
 
 func (p *Project) resolveProjectRoot(projectFile, configRoot string) {

--- a/utils/common.go
+++ b/utils/common.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Version of rivendell
-var Version = "1.1.0"
+var Version = "1.1.1"
 
 // MergeMaps merges multiple maps into one
 func MergeMaps(maps ...map[string]string) map[string]string {
@@ -79,4 +79,12 @@ func ExpandEnv(s string) string {
 		envName := strings.TrimPrefix(strings.TrimSuffix(found, ")"), "$(")
 		return os.Getenv(envName)
 	})
+}
+
+func StringSliceToMap(s []string) map[string]bool {
+	m := make(map[string]bool)
+	for _, it := range s {
+		m[it] = true
+	}
+	return m
 }


### PR DESCRIPTION
Make debug output ready to be piped into `kubectl`

Useful for things like

```
rivendell debug -o yam <project_file> | kubectl diff -f -
rivendell debug -o yam <project_file> | kubectl apply -f - --dry-run=client
```

Can pretty much replace `PrintUpPlan | PrintDownPlan | PrintUpdatePlan | PrintRestartPlan` in the future